### PR TITLE
feat(tray): dark-styled tray menu matching app theme

### DIFF
--- a/.github/ISSUE_BODIES/charts_review.md
+++ b/.github/ISSUE_BODIES/charts_review.md
@@ -1,0 +1,26 @@
+Observed issues in sparkline/graph rendering:
+
+1) Ticklines set/placement feels off
+- Currently shows 5 horizontal lines: min, ~10th, mid (50%), ~90th, max.
+- Proposal: show evenly spaced 0/25/50/75/100% gridlines, with dynamic labeling to actual ms values.
+- Ensure tick computation is consistent across Latency/Jitter and Packet Loss views.
+
+2) Gridline rendering artifacts
+- The ~10% and ~90% gridlines extend left beyond the y-axis bar.
+- Ensure gridlines are clipped within the plot area and align precisely with the y-axis boundary.
+
+3) Packet Loss baseline below zero
+- Loss chart y-axis baseline appears at about -0.5% ("packet gain").
+- Force zero baseline and clamp to [0, 100]%.
+
+Acceptance criteria
+- [ ] Replace current gridlines with evenly spaced 0/25/50/75/100% lines (computed to correct ms/% scale).
+- [ ] Gridlines do not protrude left of the y-axis; are clipped to plot bounds.
+- [ ] ForceZeroBaseline respected for both latency/jitter and loss charts; no negative baselines.
+- [ ] Labels/tooltips (if any) reflect correct dynamic ms/% values.
+- [ ] Verified on Windows 10/11, different DPI scales.
+
+Notes
+- Likely changes in Controls/SparklineControl: gridline placement, axis range calculation, and clipping.
+- Ensure minimal per-tick allocation; re-use pens/geometry and Freeze brushes.
+

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Windows;
 using System.Windows.Forms;
 using Netwatch.Services;
+using System.Drawing;
 
 namespace Netwatch
 {
@@ -40,6 +41,14 @@ namespace Netwatch
             };
 
             var menu = new ContextMenuStrip();
+            // Apply dark theme renderer to match WPF theme
+            menu.Renderer = new ToolStripProfessionalRenderer(new Services.DarkColorTable());
+            menu.ShowImageMargin = false;
+            // Font to match app typography
+            try { menu.Font = new Font("Segoe UI Variable", 9.0f, FontStyle.Regular, GraphicsUnit.Point); } catch { /* fallback to default */ }
+            menu.ForeColor = System.Drawing.ColorTranslator.FromHtml("#F7F7F8");
+            menu.BackColor = System.Drawing.ColorTranslator.FromHtml("#1E1E1F");
+
             var showMini = new ToolStripMenuItem("Show/Hide Mini HUD");
             showMini.Click += (s, ev) => ToggleMini();
             var showExpanded = new ToolStripMenuItem("Show Expanded Panel");

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -45,7 +45,7 @@ namespace Netwatch
             menu.Renderer = new ToolStripProfessionalRenderer(new Services.DarkColorTable());
             menu.ShowImageMargin = false;
             // Font to match app typography
-            try { menu.Font = new Font("Segoe UI Variable", 9.0f, FontStyle.Regular, GraphicsUnit.Point); } catch { /* fallback to default */ }
+            try { menu.Font = new System.Drawing.Font("Segoe UI Variable", 9.0f, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point); } catch { /* fallback to default */ }
             menu.ForeColor = System.Drawing.ColorTranslator.FromHtml("#F7F7F8");
             menu.BackColor = System.Drawing.ColorTranslator.FromHtml("#1E1E1F");
 

--- a/Services/DarkColorTable.cs
+++ b/Services/DarkColorTable.cs
@@ -1,0 +1,31 @@
+using System.Drawing;
+using System.Windows.Forms;
+
+namespace Netwatch.Services
+{
+    // Custom color table to style WinForms context menu to match WPF dark theme
+    internal sealed class DarkColorTable : ProfessionalColorTable
+    {
+        private static readonly Color Card = ColorTranslator.FromHtml("#1E1E1F");
+        private static readonly Color Card2 = ColorTranslator.FromHtml("#222224");
+        private static readonly Color Divider = ColorTranslator.FromHtml("#22000000");
+        private static readonly Color Highlight = ColorTranslator.FromHtml("#2A2A2A");
+        private static readonly Color Text = ColorTranslator.FromHtml("#F7F7F8");
+        private static readonly Color Muted = ColorTranslator.FromHtml("#AAAAAA");
+
+        public override Color MenuBorder => Divider;
+        public override Color MenuItemBorder => Divider;
+        public override Color ToolStripDropDownBackground => Card;
+        public override Color ImageMarginGradientBegin => Card;
+        public override Color ImageMarginGradientMiddle => Card;
+        public override Color ImageMarginGradientEnd => Card;
+        public override Color MenuItemSelected => Highlight;
+        public override Color MenuItemSelectedGradientBegin => Highlight;
+        public override Color MenuItemSelectedGradientEnd => Highlight;
+        public override Color MenuItemPressedGradientBegin => Card2;
+        public override Color MenuItemPressedGradientEnd => Card2;
+        public override Color SeparatorDark => Divider;
+        public override Color SeparatorLight => Divider;
+    }
+}
+


### PR DESCRIPTION
This PR styles the system tray context menu to match the Netwatch WPF dark theme and improves usability.

Changes
- Custom WinForms ProfessionalColorTable (Services/DarkColorTable.cs)
- App.xaml.cs: apply renderer, set font (Segoe UI Variable when available), colors, hide image margin

Why
- Consistent look and feel between HUD/Expanded windows and the tray menu
- Clearer hover/focus states on dark background

Acceptance checklist
- [ ] Visuals match Theme.xaml (card background, subtle dividers, highlight on hover)
- [ ] Tray menu renders correctly on Windows 10/11 light/dark system themes
- [ ] No regression to tray actions: Show/Hide Mini HUD, Show Expanded, Copy snapshot, Run test, Exit

Project hygiene
- Closes #16
- Labels: UI, P1
- Milestone: v0.1
